### PR TITLE
Changed labels for shelves/collections

### DIFF
--- a/koboutilities/action.py
+++ b/koboutilities/action.py
@@ -474,9 +474,9 @@ class KoboUtilitiesAction(InterfaceAction):
 
             self.create_menu_item_ex(
                 self.menu,
-                _("Order Series Shelves"),
-                unique_name="Order Series Shelves",
-                shortcut_name=_("Order Series Shelves"),
+                _("Order Series Collections"),
+                unique_name="Order Series Collections",
+                shortcut_name=_("Order Series Collections"),
                 triggered=self.order_series_shelves,
                 is_library_action=True,
                 is_device_action=True,
@@ -484,9 +484,9 @@ class KoboUtilitiesAction(InterfaceAction):
             )
             self.create_menu_item_ex(
                 self.menu,
-                _("Get Shelves From Device"),
-                unique_name="Get Shelves From Device",
-                shortcut_name=_("Get Shelves From Device"),
+                _("Get Collections From Device"),
+                unique_name="Get Collections From Device",
+                shortcut_name=_("Get Collections From Device"),
                 triggered=self.get_shelves_from_device,
                 is_library_action=True,
                 is_supported=device is not None and device.is_kobotouch,
@@ -564,9 +564,9 @@ class KoboUtilitiesAction(InterfaceAction):
             databaseMenu.addSeparator()
             self.create_menu_item_ex(
                 databaseMenu,
-                _("Fix Duplicate Shelves"),
-                unique_name="Fix Duplicate Shelves",
-                shortcut_name=_("Fix Duplicate Shelves"),
+                _("Fix Duplicate Collections"),
+                unique_name="Fix Duplicate Collections",
+                shortcut_name=_("Fix Duplicate Collections"),
                 triggered=self.fix_duplicate_shelves,
                 is_library_action=True,
                 is_device_action=True,
@@ -1726,7 +1726,7 @@ class KoboUtilitiesAction(InterfaceAction):
         if self.device is None:
             error_dialog(
                 self.gui,
-                _("Cannot fix the duplicate shelves in the device library."),
+                _("Cannot fix the duplicate Collections in the device library."),
                 _("No device connected."),
                 show=True,
             )
@@ -1748,12 +1748,12 @@ class KoboUtilitiesAction(InterfaceAction):
             _("Update summary:")
             + "\n\t"
             + _(
-                "Starting number of shelves={0}\n\tShelves removed={1}\n\tTotal shelves={2}"
+                "Starting number of Collections={0}\n\tCollections removed={1}\n\tTotal collections={2}"
             ).format(starting_shelves, shelves_removed, finished_shelves)
         )
         info_dialog(
             self.gui,
-            _("Kobo Utilities") + " - " + _("Duplicate Shelves Fixed"),
+            _("Kobo Utilities") + " - " + _("Duplicate Collections Fixed"),
             result_message,
             show=True,
         )
@@ -1763,7 +1763,7 @@ class KoboUtilitiesAction(InterfaceAction):
         if self.device is None:
             error_dialog(
                 self.gui,
-                _("Cannot order the series shelves in the device library."),
+                _("Cannot order the series Collections in the device library."),
                 _("No device connected."),
                 show=True,
             )
@@ -1786,13 +1786,13 @@ class KoboUtilitiesAction(InterfaceAction):
         result_message = (
             _("Update summary:")
             + "\n\t"
-            + _("Starting number of shelves={0}\n\tShelves reordered={1}").format(
+            + _("Starting number of collections={0}\n\tCollections reordered={1}").format(
                 starting_shelves, shelves_ordered
             )
         )
         info_dialog(
             self.gui,
-            _("Kobo Utilities") + " - " + _("Order Series Shelves"),
+            _("Kobo Utilities") + " - " + _("Order Series Collections"),
             result_message,
             show=True,
         )
@@ -1852,7 +1852,7 @@ class KoboUtilitiesAction(InterfaceAction):
         if self.device is None:
             error_dialog(
                 self.gui,
-                _("Cannot get the shelves from device."),
+                _("Cannot get the collections from device."),
                 _("No device connected."),
                 show=True,
             )
@@ -1898,10 +1898,10 @@ class KoboUtilitiesAction(InterfaceAction):
                 return
 
         progressbar = ProgressBar(
-            parent=self.gui, window_title=_("Getting shelves from device")
+            parent=self.gui, window_title=_("Getting collections from device")
         )
         progressbar.show()
-        progressbar.set_label(_("Getting list of shelves"))
+        progressbar.set_label(_("Getting list of collections"))
 
         library_db = current_view.model().db
         if self.options[cfg.KEY_ALL_BOOKS]:
@@ -1918,7 +1918,7 @@ class KoboUtilitiesAction(InterfaceAction):
         debug("selectedIDs:", selectedIDs)
         books = self._convert_calibre_ids_to_books(library_db, selectedIDs)
         progressbar.set_label(
-            _("Number of books to get shelves for {0}").format(len(books))
+            _("Number of books to get collections for {0}").format(len(books))
         )
         for book in books:
             device_book_paths = self.get_device_paths_from_id(book.calibre_id)
@@ -1938,12 +1938,12 @@ class KoboUtilitiesAction(InterfaceAction):
             _("Update summary:")
             + "\n\t"
             + _(
-                "Books processed={0}\n\tBooks with Shelves={1}\n\tBooks without Shelves={2}"
+                "Books processed={0}\n\tBooks with Collections={1}\n\tBooks without Collections={2}"
             ).format(count_books, books_with_shelves, books_without_shelves)
         )
         info_dialog(
             self.gui,
-            _("Kobo Utilities") + " - " + _("Get Shelves from Device"),
+            _("Kobo Utilities") + " - " + _("Get Collections from Device"),
             result_message,
             show=True,
         )
@@ -3820,7 +3820,7 @@ class KoboUtilitiesAction(InterfaceAction):
 
         debug("shelves:", shelves, " options:", options)
         progressbar = ProgressBar(
-            parent=self.gui, window_title=_("Order Series Shelves")
+            parent=self.gui, window_title=_("Order Series Collections")
         )
         progressbar.show_with_maximum(len(shelves))
         progressbar.left_align_label()

--- a/koboutilities/dialogs.py
+++ b/koboutilities/dialogs.py
@@ -1349,17 +1349,17 @@ class GetShelvesFromDeviceDialog(SizePersistedDialog):
         self.all_books_checkbox = QCheckBox(_("All books on device"), self)
         self.all_books_checkbox.setToolTip(
             _(
-                "Get the shelves for all the books on the device that are in the library. If not checked, will only get them for the selected books."
+                "Get the collections for all the books on the device that are in the library. If not checked, will only get them for the selected books."
             )
         )
         options_layout.addWidget(self.all_books_checkbox, 1, 0, 1, 2)
 
         self.replace_shelves_checkbox = QCheckBox(
-            _("Replace column with shelves"), self
+            _("Replace column with collections"), self
         )
         self.replace_shelves_checkbox.setToolTip(
             _(
-                "If this is selected, the current value in the library, will be replaced by\nthe retrieved shelves. Otherwise, the retrieved shelves will be added to the value"
+                "If this is selected, the current value in the library, will be replaced by\nthe retrieved collections. Otherwise, the retrieved collections will be added to the value"
             )
         )
         options_layout.addWidget(self.replace_shelves_checkbox, 2, 0, 1, 2)
@@ -3542,11 +3542,11 @@ class FixDuplicateShelvesDialog(SizePersistedDialog):
         self.resize_dialog()
 
     def initialize_controls(self):
-        self.setWindowTitle(_("Duplicate Shelves in Device Database"))
+        self.setWindowTitle(_("Duplicate Collections in Device Database"))
         layout = QVBoxLayout(self)
         self.setLayout(layout)
         title_layout = ImageTitleLayout(
-            self, "images/manage_series.png", _("Duplicate Shelves in Device Database")
+            self, "images/manage_series.png", _("Duplicate Collections in Device Database")
         )
         layout.addLayout(title_layout)
 
@@ -3740,10 +3740,10 @@ class OrderSeriesShelvesDialog(SizePersistedDialog):
         layout.addLayout(title_layout)
 
         order_shelves_type_toolTip = [
-            _("Order the shelves with series names."),
-            _("Order the shelves with author names."),
-            _("Order the shelves that do not have series or author names."),
-            _("Order all shelves."),
+            _("Order the collections with series names."),
+            _("Order the collections with author names."),
+            _("Order the collections that do not have series or author names."),
+            _("Order all collections."),
         ]
 
         order_shelves_type_group_box = QGroupBox(_("Shelves to order"), self)


### PR DESCRIPTION
I changed instances of 'shelves' in labels/tooltips to 'collections' to reduce confusion. Kept internal names though.

May have made mistakes or missed some, so extra-check before merging.